### PR TITLE
Refine chart title overlay style

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,11 +320,11 @@
             top: -20px;
             left: 50%;
             transform: translateX(-50%);
-            background: rgba(255, 255, 255, 0.05);
-            backdrop-filter: blur(18px);
-            -webkit-backdrop-filter: blur(18px);
+            background: rgba(255, 255, 255, 0.03);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
             color: var(--white);
-            padding: 16px 24px;
+            padding: 12px 20px;
             border-radius: 16px;
             z-index: 3;
             border: 1px solid rgba(255, 255, 255, 0.15);
@@ -340,7 +340,7 @@
         .chart-title-overlay h3 {
             color: var(--white);
             font-size: 1.5rem;
-            margin: 0 0 6px 0; /* Add margin-bottom for spacing */
+            margin: 0 0 4px 0; /* Reduced spacing */
             font-weight: 700;
             text-shadow: 0 2px 6px rgba(0,0,0,0.5);
             white-space: nowrap; /* Keep title on a single line */
@@ -1142,7 +1142,7 @@
             }
             
              .chart-title-overlay {
-                padding: 12px 18px;
+                padding: 8px 14px;
                 top: -10px;
                 line-height: 1.3;
             }


### PR DESCRIPTION
## Summary
- reduce padding for the chart title overlay
- make overlay background more transparent
- slightly reduce spacing under the heading
- adjust responsive padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ac60d7bcc8331b2333669b6324dd1