### PR TITLE
Fix Stats heading text wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
 
         .stat-item h3 {
             font-size: 3rem;
-            white-space: nowrap;
+            white-space: normal;
             font-weight: 800;
             color: var(--primary-purple);
             margin-bottom: 12px;
@@ -391,6 +391,10 @@
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
+        }
+
+        .stat-item h3[contenteditable="true"] {
+            display: block;
         }
 
         .stat-item p { 


### PR DESCRIPTION
## Summary
- ensure stat headings wrap correctly on small screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685acb36b5a483319053b7e0526f622a